### PR TITLE
Add --drop and fix config url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker-compose up
 poetry run ecospheres-search index --config={path/to/ecospheres-front/config.yaml}
 ```
 
+Use `--drop` to delete all documents in the index before reindexing.
+
 ### Set the custom settings on the index
 
 Uses the settings defined in `settings.yaml`.


### PR DESCRIPTION
Related to https://github.com/ecolabdata/ecospheres-front/pull/44

- `--drop` for resetting the index
- use the new config var for data.gouv.fr's API url